### PR TITLE
Update footer: responsive widths for tablet/desktop and hover expansion on desktop

### DIFF
--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
 
@@ -16,24 +16,6 @@ export default function DocsPage() {
         </div>
 
         <div className="max-w-4xl mx-auto">
-          <Card className="shadow-zen mb-8">
-            <CardHeader>
-              <CardTitle className="text-tea-700">🚀 Getting Started</CardTitle>
-              <CardDescription>
-                Follow these steps to begin planning your Japan adventure
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <ol className="list-decimal list-inside space-y-2 text-stone-600">
-                <li>Create an account or sign in</li>
-                <li>Create your first trip with dates</li>
-                <li>Add destinations and plan your itinerary</li>
-                <li>Track expenses and manage reservations</li>
-                <li>Use checklists to prepare for your journey</li>
-              </ol>
-            </CardContent>
-          </Card>
-
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
             <Card className="shadow-zen">
               <CardHeader>
@@ -70,7 +52,7 @@ export default function DocsPage() {
                 Back to Home
               </Button>
             </Link>
-            <Link href="/itinerary">
+            <Link href="/get-started">
               <Button variant="outline" className="border-tea-600 text-tea-700 hover:bg-tea-50">
                 Get Started
               </Button>

--- a/app/get-started/page.tsx
+++ b/app/get-started/page.tsx
@@ -1,0 +1,53 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import Link from "next/link"
+
+export default function GetStartedPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-tea-50 via-stone-50 to-bamboo-50">
+      <div className="container mx-auto px-4 py-16">
+        <div className="text-center mb-12">
+          <h1 className="text-4xl md:text-6xl font-heading font-bold text-stone-800 mb-4">
+            Get Started
+          </h1>
+          <p className="text-lg md:text-xl text-stone-600 text-zen max-w-2xl mx-auto">
+            Follow these steps to begin planning your Japan adventure
+          </p>
+        </div>
+
+        <div className="max-w-4xl mx-auto">
+          <Card className="shadow-zen mb-8">
+            <CardHeader>
+              <CardTitle className="text-tea-700">🚀 Getting Started</CardTitle>
+              <CardDescription>
+                Follow these steps to begin planning your Japan adventure
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ol className="list-decimal list-inside space-y-2 text-stone-600">
+                <li>Create an account or sign in</li>
+                <li>Create your first trip with dates</li>
+                <li>Add destinations and plan your itinerary</li>
+                <li>Track expenses and manage reservations</li>
+                <li>Use checklists to prepare for your journey</li>
+              </ol>
+            </CardContent>
+          </Card>
+
+          <div className="text-center">
+            <Link href="/itinerary">
+              <Button className="bg-tea-600 hover:bg-tea-700 text-white mr-4">
+                Start Planning
+              </Button>
+            </Link>
+            <Link href="/">
+              <Button variant="outline" className="border-tea-600 text-tea-700 hover:bg-tea-50">
+                Back to Home
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,25 +1,46 @@
 import Link from "next/link";
+import { Button } from "@/components/ui/button";
 
 export default function Footer() {
   return (
-    <footer className="mt-16 bg-white/70 backdrop-blur border-t border-stone-200">
-      <div className="container mx-auto px-4 py-10">
-        <h2 className="text-lg font-heading font-semibold text-stone-800 mb-6">
-          Quick Links
-        </h2>
-        <nav aria-label="Quick Links">
-          <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3 text-stone-700">
-            <li><Link href="/itinerary" className="hover:text-tea-700">Itinerary</Link></li>
-            <li><Link href="/expenses" className="hover:text-tea-700">Expenses</Link></li>
-            <li><Link href="/activities" className="hover:text-tea-700">Activities</Link></li>
-            <li><Link href="/docs" className="hover:text-tea-700">Docs</Link></li>
-            <li><Link href="/checklists" className="hover:text-tea-700">Checklists</Link></li>
-            <li><Link href="/reservations" className="hover:text-tea-700">Reservations</Link></li>
-            <li><Link href="/dashboard" className="hover:text-tea-700">Dashboard</Link></li>
-          </ul>
-        </nav>
+    <footer className="mt-16">
+      {/* Pink banner section with pill-style links */}
+      <div className="container mx-auto px-4 py-8">
+        <div className="rounded-2xl shadow-zen border bg-sakura-100/80 p-8 text-center">
+          <h2 className="text-lg font-heading font-semibold text-stone-800 mb-6">
+            Quick Links
+          </h2>
+          <nav aria-label="Quick Links">
+            <div className="flex flex-wrap justify-center gap-3 mb-6">
+              <Link href="/itinerary" className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm hover:bg-white/90 transition-colors">
+                Itinerary
+              </Link>
+              <Link href="/checklists" className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm hover:bg-white/90 transition-colors">
+                Checklists
+              </Link>
+              <Link href="/expenses" className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm hover:bg-white/90 transition-colors">
+                Expenses
+              </Link>
+              <Link href="/reservations" className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm hover:bg-white/90 transition-colors">
+                Reservations
+              </Link>
+              <Link href="/activities" className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm hover:bg-white/90 transition-colors">
+                Activities
+              </Link>
+              <Link href="/dashboard" className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm hover:bg-white/90 transition-colors">
+                Dashboard
+              </Link>
+            </div>
+            <Link href="/get-started">
+              <Button className="bg-tea-600 hover:bg-tea-700 text-white">
+                Get Started
+              </Button>
+            </Link>
+          </nav>
+        </div>
       </div>
 
+      {/* Bottom copyright bar */}
       <div className="border-t border-stone-200">
         <div className="container mx-auto px-4 py-4 flex items-center justify-between text-sm text-stone-600">
           <span>© Creatives City. All Rights Reserved 2025</span>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,52 +3,70 @@ import { Button } from "@/components/ui/button";
 
 export default function Footer() {
   return (
-    <footer className="mt-16">
-      {/* Pink banner section with pill-style links */}
-      <div className="container mx-auto px-4 py-8">
-        <div className="rounded-2xl shadow-zen border bg-sakura-100/80 p-8 text-center">
-          <h2 className="text-lg font-heading font-semibold text-stone-800 mb-6">
-            Quick Links
-          </h2>
-          <nav aria-label="Quick Links">
-            <div className="flex flex-wrap justify-center gap-3 mb-6">
-              <Link href="/itinerary" className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm hover:bg-white/90 transition-colors">
-                Itinerary
+      <footer className="mt-16">
+        {/* Pink banner section with pill-style links */}
+        <div className="container mx-auto px-4 py-8">
+          <div className="w-full md:w-3/4 lg:w-1/2 mx-auto rounded-2xl shadow-zen border bg-sakura-100/80 p-8 text-center">
+            <h2 className="text-lg font-heading font-semibold text-stone-800 mb-6">
+              Quick Links
+            </h2>
+            <nav aria-label="Quick Links">
+              <div className="flex flex-wrap justify-center gap-3 mb-6">
+                <Link
+                    href="/itinerary"
+                    className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm transition-all duration-300 hover:bg-white/90 lg:hover:shadow-zen-lg lg:hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-tea-400 focus-visible:ring-offset-2"
+                >
+                  Itinerary
+                </Link>
+                <Link
+                    href="/checklists"
+                    className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm transition-all duration-300 hover:bg-white/90 lg:hover:shadow-zen-lg lg:hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-tea-400 focus-visible:ring-offset-2"
+                >
+                  Checklists
+                </Link>
+                <Link
+                    href="/expenses"
+                    className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm transition-all duration-300 hover:bg-white/90 lg:hover:shadow-zen-lg lg:hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-tea-400 focus-visible:ring-offset-2"
+                >
+                  Expenses
+                </Link>
+                <Link
+                    href="/reservations"
+                    className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm transition-all duration-300 hover:bg-white/90 lg:hover:shadow-zen-lg lg:hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-tea-400 focus-visible:ring-offset-2"
+                >
+                  Reservations
+                </Link>
+                <Link
+                    href="/activities"
+                    className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm transition-all duration-300 hover:bg-white/90 lg:hover:shadow-zen-lg lg:hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-tea-400 focus-visible:ring-offset-2"
+                >
+                  Activities
+                </Link>
+                <Link
+                    href="/dashboard"
+                    className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm transition-all duration-300 hover:bg-white/90 lg:hover:shadow-zen-lg lg:hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-tea-400 focus-visible:ring-offset-2"
+                >
+                  Dashboard
+                </Link>
+              </div>
+              <Link href="/get-started">
+                <Button className="bg-tea-600 hover:bg-tea-700 text-white transition-transform duration-300 lg:hover:scale-105">
+                  Get Started
+                </Button>
               </Link>
-              <Link href="/checklists" className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm hover:bg-white/90 transition-colors">
-                Checklists
-              </Link>
-              <Link href="/expenses" className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm hover:bg-white/90 transition-colors">
-                Expenses
-              </Link>
-              <Link href="/reservations" className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm hover:bg-white/90 transition-colors">
-                Reservations
-              </Link>
-              <Link href="/activities" className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm hover:bg-white/90 transition-colors">
-                Activities
-              </Link>
-              <Link href="/dashboard" className="bg-white/70 border border-stone-200 px-3 py-1 rounded-full shadow-zen text-sm hover:bg-white/90 transition-colors">
-                Dashboard
-              </Link>
-            </div>
-            <Link href="/get-started">
-              <Button className="bg-tea-600 hover:bg-tea-700 text-white">
-                Get Started
-              </Button>
-            </Link>
-          </nav>
+            </nav>
+          </div>
         </div>
-      </div>
 
-      {/* Bottom copyright bar */}
-      <div className="border-t border-stone-200">
-        <div className="container mx-auto px-4 py-4 flex items-center justify-between text-sm text-stone-600">
-          <span>© Creatives City. All Rights Reserved 2025</span>
-          <Link href="/built-with-modern-technology" className="text-tea-700 hover:text-tea-800">
-            Built with Modern Technology
-          </Link>
+        {/* Bottom copyright bar */}
+        <div className="border-t border-stone-200">
+          <div className="container mx-auto px-4 py-4 flex items-center justify-between text-sm text-stone-600">
+            <span>© Creatives City. All Rights Reserved 2025</span>
+            <Link href="/built-with-modern-technology" className="text-tea-700 hover:text-tea-800">
+              Built with Modern Technology
+            </Link>
+          </div>
         </div>
-      </div>
-    </footer>
+      </footer>
   );
 }


### PR DESCRIPTION
Summary

- Implements responsive footer card width: mobile 100% (existing), tablet 75%, desktop/wide 50%.

- Adds desktop-only hover expansion (scale + shadow) for pill links and “Get Started” CTA, matching home page cards.

Changes

- components/Footer.tsx: responsive width classes (md:w-3/4, lg:w-1/2)

- Add lg:hover:scale-105 and lg:hover:shadow-… on pill links and CTA

- Preserve focus styles and existing visuals

Testing

- Resize to verify widths at ≥768px (75%) and ≥1024px (50%).
- Hover over pills/CTA on desktop; confirm scale/shadow bump.
- Check keyboard focus rings remain visible.

Notes

- Follow-up tweaks welcome (hover intensity, timing, or pink shade).
- Base/compare reminder

Base: main
Compare: pr-9-get-started
If needed, rebase first: git fetch origin && git rebase origin/main on pr-9-get-started